### PR TITLE
fix bug when file is in UNIX format

### DIFF
--- a/lib/patterns/cpp.js
+++ b/lib/patterns/cpp.js
@@ -15,6 +15,11 @@ exports.applyToGenerator = function (g) {
             return;
         }
 
+        if (t.code.contains("typedef ")) {
+            t.header = "🔘 " + t.code;
+            return;
+        }        
+
         t.header = "Ⓜ️ " + t.code;
     });
     

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -13,8 +13,9 @@ function parseCode(text)
         return lines.shift();
     }
     
-    while(line = nextLine())
+    while(lines.length > 0)
     {
+        line = nextLine();
         var l = line.trim();
         
         if (!l.startsWith("/**")) {


### PR DESCRIPTION
Hello! I found this tool very useful and simple. But it didn't work with files in UNIX format. As the character of new line used on Windows and Linux are different, the while() exits in the first line break it finds once `line` is considered empty.

Running `cat -A` you can the difference of new line  chars

Yours
```
// simple c header^M$
^M$
/**^M$
 * # Calculator functions ^M$
 * ^M$
 * This is simple c header file for fictive calculator^M$
 */^M$
^M$
``` 

Mine
```
#pragma once$
$
#include <Arduino.h>$
#include <WiFi.h>$
#include <Stream.h>$
#include "improv.h"$
$
#ifndef MAX_ATTEMPTS_WIFI_CONNECTION$
#define MAX_ATTEMPTS_WIFI_CONNECTION 20$
#endif$
#ifndef DELAY_MS_WAIT_WIFI_CONNECTION$
#define DELAY_MS_WAIT_WIFI_CONNECTION 500$
#endif$
$
/**$
```

